### PR TITLE
Handled panic in Async func in a non-blocking way

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,14 @@ func GetUserName(id time.Duration) *eventloop.Promise {
 	})
 }
 
+func GetUserNameWithPanic() *eventloop.Promise {
+    return GlobalEventLoop.Async(func() (interface{}, error) {
+        <-time.After(time.Second * 2)
+        panic("panic attack")
+    })
+}
+
+
 func main() {
 	GlobalEventLoop.Main(func() {
 		result := GetUserName(2)
@@ -39,8 +47,15 @@ func main() {
 		}).Catch(func(err error) {
 			fmt.Println("15 : err:", err)
 		})
+		
+		//  promise with panic 
+		GetUserNameWithPanic().Then(func(i interface{}) {
+			fmt.Println("Then block never gets triggered")
+		}).Catch(func(err error) {
+			fmt.Println("GetUserNameWithPanic err: ", err)
+		})
 
-		//	await
+		//  await
 		syncResult1 := GlobalEventLoop.Await(GetUserName(4))
 		fmt.Println("4 : user:", syncResult1)
 
@@ -54,7 +69,7 @@ func main() {
 
 		fmt.Println("done")
 
-		//nested promise
+		//  nested promise
 		GlobalEventLoop.Async(func() (interface{}, error) {
 			fmt.Println("outer async")
 			GlobalEventLoop.Async(func() (interface{}, error) {
@@ -78,6 +93,7 @@ func main() {
 ```shell
 run before promise returns
 0 : err: some error id(0s)
+GetUserNameWithPanic err:  panic attack
 2 : user: id(2ns): Test User
 4 : user: id(4ns): Test User
 5 : user: id(5ns): Test User

--- a/main.go
+++ b/main.go
@@ -24,8 +24,16 @@ func GetUserName(id time.Duration) *eventloop.Promise {
 	})
 }
 
+func GetUserNameWithPanic() *eventloop.Promise {
+	return GlobalEventLoop.Async(func() (interface{}, error) {
+		<-time.After(time.Second * 2)
+		panic("panic attack")
+	})
+}
+
 func main() {
 	GlobalEventLoop.Main(func() {
+
 		result := GetUserName(2)
 
 		result.Then(func(x interface{}) {
@@ -51,6 +59,13 @@ func main() {
 			fmt.Println("15 : user:", x)
 		}).Catch(func(err error) {
 			fmt.Println("15 : err:", err)
+		})
+
+		//promise with panic
+		GetUserNameWithPanic().Then(func(i interface{}) {
+			fmt.Println("Then block never gets triggered")
+		}).Catch(func(err error) {
+			fmt.Println("GetUserNameWithPanic err: ", err)
 		})
 
 		//	await


### PR DESCRIPTION
introduced a `promiseRecovery` func to handle data transfer on`resultChan` and`errChan` in a non-blocking way