### PR TITLE
Basic Future Implementation

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -160,3 +160,71 @@ func (p *Promise) Catch(fn func(err error)) {
 		}
 	}()
 }
+
+type Future struct {
+	completeChan  chan interface{}
+	onComFunc     interface{}
+	completeEvent []interface{}
+	signalCount   int // could be useful
+}
+
+func (e *EventLoop) NewFuture() *Future {
+	return &Future{completeChan: make(chan interface{})}
+}
+
+func (f *Future) GetCompleteEventFromFuture(signalId int) interface{} {
+	if signalId < f.signalCount {
+		return f.completeEvent[signalId]
+	}
+	return nil
+}
+
+func (f *Future) GetCompleteEventsFromFuture() []interface{} {
+	return f.completeEvent
+}
+
+func (f *Future) Set(value interface{}, future string) {
+	switch future {
+	case "complete":
+		f.completeChan <- value
+	default:
+	}
+}
+
+func (f *Future) RegisterComplete(futureFunc interface{}) {
+	f.onComFunc = futureFunc
+}
+
+func (f *Future) Signal() {
+	// maybe this should be a blocking call?
+	go func() {
+	Loop:
+		for {
+			select {
+			case e := <-f.completeChan:
+				f.completeEvent = append(f.completeEvent, e)
+				f.signalCount++
+				break Loop
+			default:
+				break Loop
+			}
+		}
+	}()
+}
+
+func (f *Future) SignalComplete(value interface{}) {
+	if f.onComFunc != nil {
+		go func() {
+			f.onComFunc.(func(interface{}))(value)
+			// should handle error here -- only if user registered a function for a future error event
+			f.Set(value, "complete")
+		}()
+		f.Signal()
+	} else {
+		panic("no function registered for future event [SignalComplete]")
+	}
+}
+
+func (f *Future) SigalCount() int {
+	return f.signalCount
+}

--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -183,7 +183,7 @@ func (f *Future) GetCompleteEventsFromFuture() []interface{} {
 	return f.completeEvent
 }
 
-func (f *Future) Set(value interface{}, future string) {
+func (f *Future) set(value interface{}, future string) {
 	switch future {
 	case "complete":
 		f.completeChan <- value
@@ -195,7 +195,7 @@ func (f *Future) RegisterComplete(futureFunc interface{}) {
 	f.onComFunc = futureFunc
 }
 
-func (f *Future) Signal() {
+func (f *Future) signal() {
 	// maybe this should be a blocking call?
 	go func() {
 	Loop:
@@ -217,9 +217,9 @@ func (f *Future) SignalComplete(value interface{}) {
 		go func() {
 			f.onComFunc.(func(interface{}))(value)
 			// should handle error here -- only if user registered a function for a future error event
-			f.Set(value, "complete")
+			f.set(value, "complete")
 		}()
-		f.Signal()
+		f.signal()
 	} else {
 		panic("no function registered for future event [SignalComplete]")
 	}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ func GetUserNameWithPanic() *eventloop.Promise {
 func main() {
 	GlobalEventLoop.Main(func() {
 
+		f := GlobalEventLoop.NewFuture()
+
+		f.RegisterComplete(func(data interface{}) {
+			fmt.Println("Received data from future --> ", data.(string))
+		})
+
 		result := GetUserName(2)
 
 		result.Then(func(x interface{}) {
@@ -48,6 +54,13 @@ func main() {
 			fmt.Println("0 : err:", err)
 		})
 
+		go func() {
+			<-time.After(4 * time.Second)
+			f.SignalComplete("completed after 4 seconds")
+		}()
+
+		f.SignalComplete("another hello world")
+
 		GetUserName(5).Then(func(x interface{}) {
 			fmt.Println("5 : user:", x)
 			panic("a panic attack")
@@ -60,6 +73,11 @@ func main() {
 		}).Catch(func(err error) {
 			fmt.Println("15 : err:", err)
 		})
+
+		go func() {
+			<-time.After(2 * time.Second)
+			f.SignalComplete("completed after 2 seconds")
+		}()
 
 		//promise with panic
 		GetUserNameWithPanic().Then(func(i interface{}) {


### PR DESCRIPTION
- create a Future from the global Eventloop
-  register a function for the complete Future event
-  signal the complete Future event to be executed with parameters
- signal multiple times if needed

# Notes
- neither the Eventloop nor the created Future blocks the execution of the main routine
- the consumer of a Future would have to handle blocking their main routine as they have the most control over it. 